### PR TITLE
Some fixes

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -62,7 +62,7 @@ function encodeLink(path, value, attrs) {
             break;
     }
 
-    if (linkFormat[linkFormat.length-1] === ',')           
+    if (linkFormat[linkFormat.length-1] === ',')
         linkFormat = linkFormat.slice(0, linkFormat.length - 1);
 
     return linkFormat;
@@ -80,15 +80,15 @@ function encodeTlv(path, value) {
     pathArray = cutils.getPathArray(path);
 
     switch (pathType) {
-        case 'object': 
+        case 'object':
             data = encodeTlvPacket('object', path, pathArray[0], value);
             break;
 
-        case 'instance': 
+        case 'instance':
             data = encodeTlvPacket('instance', path, pathArray[1], value);
             break;
 
-        case 'resource': 
+        case 'resource':
             if (_.isPlainObject(value)) {
                 data = encodeTlvPacket('multiResrc', path, pathArray[2], value);
             } else {
@@ -135,7 +135,7 @@ function encodeTlvPacket(type, path, id, value) {
 
             dataBuf = encodeTlvBuf(type, id, Buffer.concat(valBuf));
             break;
-            
+
         case 'multiResrc':
             valBuf = [];
 
@@ -144,7 +144,7 @@ function encodeTlvPacket(type, path, id, value) {
             });
 
             dataBuf = encodeTlvBuf(type, id, Buffer.concat(valBuf));
-            break; 
+            break;
 
         case 'resource':
         case 'resrcInst':
@@ -169,20 +169,20 @@ function encodeTlvBuf(type, id, valBuf) {
         idType;
 
 /***************************
- *  TYPE                   * 
+ *  TYPE                   *
  ***************************/
     switch (type) {
-        case 'instance':         
+        case 'instance':
             byte = byte | 0x00;
             break;
-        case 'resource':         
+        case 'resource':
             byte = byte | 0xC0;
             break;
-        case 'multiResrc':        
+        case 'multiResrc':
             byte = byte | 0x80;
             break;
-        case 'resrcInst':         
-            byte = byte | 0x40;        
+        case 'resrcInst':
+            byte = byte | 0x40;
             break;
     }
 
@@ -198,7 +198,7 @@ function encodeTlvBuf(type, id, valBuf) {
     // [TODO] else Error
     if (len < 8)
         byte = byte | len;
-    else if (len < 256) 
+    else if (len < 256)
         byte = byte | 0x08;
     else if (len < 65536)
         byte = byte | 0x10;
@@ -209,7 +209,7 @@ function encodeTlvBuf(type, id, valBuf) {
     typeBuf.writeUInt8(byte);
 
 /***************************
- *  ID                     * 
+ *  ID                     *
  ***************************/
     if (idType === 'uint16be') {
         idBuf = cutils.bufferAlloc(2);
@@ -220,7 +220,7 @@ function encodeTlvBuf(type, id, valBuf) {
     }
 
 /***************************
- *  LENGTH                 * 
+ *  LENGTH                 *
  ***************************/
     if (len >= 8 && len < 256) {
         lenBuf = cutils.bufferAlloc(1);
@@ -237,7 +237,7 @@ function encodeTlvBuf(type, id, valBuf) {
     }
 
 /***************************
- *  VALUE                  * 
+ *  VALUE                  *
  ***************************/
     dataBuf = Buffer.concat([typeBuf, idBuf, lenBuf, valBuf]);
 
@@ -252,9 +252,9 @@ function encodeTlvResrc(resrcType, value) {
         if (_.isBoolean(value)) {
             resrcType = 'boolean';
         } else if (_.isNumber(value)) {
-            if (_.isInteger(value)) 
+            if (_.isInteger(value))
                 resrcType = 'integer';
-            else 
+            else
                 resrcType = 'float';
         } else if (_.isString(value)) {
             resrcType = 'string';
@@ -263,11 +263,21 @@ function encodeTlvResrc(resrcType, value) {
 
     switch (resrcType) {
         case 'boolean':
+            dataBuf = cutils.bufferAlloc(1);
             dataBuf.uint8(value ? 1 : 0);
             break;
 
         case 'time':
-            value = value.getTime();
+            //value = value.getTime();
+            value = value.toString(16);
+            zLen = 16 - value.length;
+
+            for (var i = 0; i < zLen; i++) {
+                value = '0' + value;
+            }
+
+            dataBuf = cutils.bufferFrom(value, 'hex');
+            
         case 'integer':
             len = cutils.length(value);
 
@@ -316,15 +326,15 @@ function encodeTlvResrc(resrcType, value) {
  * Json                                                  *
  *********************************************************/
 function encodeJson(path, value) {
-    var objInJson = { 
-            bn: cutils.getNumPath(path), 
-            e: [] 
+    var objInJson = {
+            bn: cutils.getNumPath(path),
+            e: []
         },
         pathType = cutils.getPathDateType(path),
         pathArray = cutils.getPathArray(path),
         oid = pathArray[0];
 
-    if (pathType !== 'resource' && !_.isPlainObject(value)) 
+    if (pathType !== 'resource' && !_.isPlainObject(value))
         throw new TypeError('value should be an object.');
 
     switch (pathType) {
@@ -393,7 +403,7 @@ function encodeJsonValue(path, value) {
     } else if (_.isString(value)) {
         val.sv = String(value);
     } else if (value instanceof Date) {
-        val.v = Number(value);       
+        val.v = Number(value);
     } else if (_.isBoolean(value)) {
         val.bv = Boolean(value);
     } else if (_.isPlainObject(value)) {

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -314,6 +314,10 @@ function encodeTlvResrc(resrcType, value) {
             dataBuf = cutils.bufferFrom(value, 'utf8');
             break;
 
+        case 'execute':
+            dataBuf = cutils.bufferFrom(value, 'utf8');
+            break;
+
         // [TODO] Objlnk
         default:
             break;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -264,7 +264,7 @@ function encodeTlvResrc(resrcType, value) {
     switch (resrcType) {
         case 'boolean':
             dataBuf = cutils.bufferAlloc(1);
-            dataBuf.uint8(value ? 1 : 0);
+            dataBuf.writeUInt8(value ? 1 : 0);
             break;
 
         case 'time':
@@ -277,7 +277,7 @@ function encodeTlvResrc(resrcType, value) {
             }
 
             dataBuf = cutils.bufferFrom(value, 'hex');
-            
+
         case 'integer':
             len = cutils.length(value);
 


### PR DESCRIPTION
Handling of TLV boolean and time resources cause errors -> fixed
When TLV instance is read, the executable resources cause error -> fixed so that the resource value "_exec_" is read instead of error